### PR TITLE
Add flag to copy s3 zip metadata to unzipped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A simple library to unzip an archive file in a S3 bucket to its root folder.
 - `<targetBucket>` : the output bucket
 - `<targetKey>` : target folder
 - `-d, --delete-on-success` : Delete the zip file once the decompression has finished
+- `-m, --copy-metadata` : Copy S3 metadata from zip file to unzipped files
 - `-v, --verbose` : Show the console log messages during runtime
 
 #### Example ####
@@ -48,6 +49,7 @@ var s = new s3Unziplus({
     targetBucket: "test-output-bucket",
     targetKey: "test-folder",
     deleteOnSuccess: true,
+    copyMetadata: false,
     verbose: false
   }, function(err, success){
     if (err) console.error(err);

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A simple library to unzip an archive file in a S3 bucket to its root folder.
 - `<targetBucket>` : the output bucket
 - `<targetKey>` : target folder
 - `-d, --delete-on-success` : Delete the zip file once the decompression has finished
-- `-m, --copy-metadata` : Copy S3 metadata from zip file to unzipped files
 - `-v, --verbose` : Show the console log messages during runtime
 
 #### Example ####
@@ -48,8 +47,8 @@ var s = new s3Unziplus({
     file: "Companies.zip",
     targetBucket: "test-output-bucket",
     targetKey: "test-folder",
+    copyMetadata: true,
     deleteOnSuccess: true,
-    copyMetadata: false,
     verbose: false
   }, function(err, success){
     if (err) console.error(err);

--- a/bin/s3-unzip-plus
+++ b/bin/s3-unzip-plus
@@ -32,6 +32,7 @@ command
 command
   .usage("[options] <S3 bucket name> <filename>")
   .option("-d --delete-on-success", "Delete the zip file on S3 once the decompression has finished")
+  .option("-m --copy-metadata', 'Copy S3 metadata from zip file to unzipped files")
   .option("-v --verbose", "Show all console logs")
   .parse(process.argv);
 

--- a/index.js
+++ b/index.js
@@ -19,34 +19,34 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-"use strict";
+'use strict'
 
-var Utils = require("./util");
+var Utils = require('./util')
 
-function s3UnzipPlus(command, cb){
-  if (cb === undefined) {cb = function(err, success) {};}
-  var vBucket, vFile, vTargetBucket, vTargetFolder;
+function s3UnzipPlus(command, cb) {
+  if (cb === undefined) { cb = function () { } }
+  var vBucket, vFile, vTargetBucket, vTargetFolder
   if (command.args && command.args.length >= 4) {
-    vBucket = command.args[0];
-    vFile = command.args[1];
-    vTargetBucket = command.args[2];
-    vTargetFolder = command.args[3];
+    vBucket = command.args[0]
+    vFile = command.args[1]
+    vTargetBucket = command.args[2]
+    vTargetFolder = command.args[3]
   }
   if (command.bucket) {
-    vBucket = command.bucket;
+    vBucket = command.bucket
   }
   if (command.file) {
-    vFile = command.file;
+    vFile = command.file
   }
   if (command.targetBucket) {
-      vTargetBucket = command.targetBucket;
+    vTargetBucket = command.targetBucket
   } else {
-      vTargetBucket = command.bucket;
+    vTargetBucket = command.bucket
   }
   if (command.targetFolder) {
-      vTargetFolder = command.targetFolder;
+    vTargetFolder = command.targetFolder
   } else {
-      vTargetFolder = '';
+    vTargetFolder = ''
   }
   Utils.decompress({
     bucket: vBucket,
@@ -56,18 +56,17 @@ function s3UnzipPlus(command, cb){
     deleteOnSuccess: command.deleteOnSuccess,
     copyMetadata: command.copyMetadata,
     verbose: command.verbose
-  }, cb);
+  }, cb)
 }
 
-module.exports = s3UnzipPlus;
+module.exports = s3UnzipPlus
 
-module.exports.handler = function(event, context, callback) {
-  if (callback === undefined) {callback = function(err, success) {};}
+module.exports.handler = function (event, context, callback) {
+  if (callback === undefined) { callback = function () { } }
   Utils.decompress({
     bucket: event.Records[0].s3.bucket.name,
     file: event.Records[0].s3.object.key,
     deleteOnSuccess: true,
-    copyMetadata: false,
     verbose: true
-  }, callback);
-};
+  }, callback)
+}

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function s3UnzipPlus(command, cb){
     targetBucket: vTargetBucket,
     targetFolder: vTargetFolder,
     deleteOnSuccess: command.deleteOnSuccess,
+    copyMetadata: command.copyMetadata,
     verbose: command.verbose
   }, cb);
 }
@@ -66,6 +67,7 @@ module.exports.handler = function(event, context, callback) {
     bucket: event.Records[0].s3.bucket.name,
     file: event.Records[0].s3.object.key,
     deleteOnSuccess: true,
+    copyMetadata: false,
     verbose: true
   }, callback);
 };

--- a/util.js
+++ b/util.js
@@ -19,137 +19,118 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-"use strict";
+'use strict'
 
-var AWS = require("aws-sdk");
-var s3 = new AWS.S3();
-var AdmZip = require("adm-zip");
-var fs = require("fs");
-var dateTime = require("date-time");
-var md5 = require("md5");
-var mime = require('mime-types');
+var AWS = require('aws-sdk')
+var s3 = new AWS.S3()
+var AdmZip = require('adm-zip')
+var fs = require('fs')
+var dateTime = require('date-time')
+var md5 = require('md5')
+var mime = require('mime-types')
 
-var decompress = function(/*String*/command, /*Function*/ cb) {
-
-  let targetBucket = command.hasOwnProperty('targetBucket') ? command.targetBucket : command.bucket;
-  let targetFolder = command.hasOwnProperty('targetFolder') ? command.targetFolder : '';
-  if (targetFolder.length>0) targetFolder +='/';
-  if (!command.bucket || !command.file) { //bucket and file are required
-    if (cb) cb(new Error("Error: missing either bucket name, full filename, targetBucket or targetKey!"));
-    else console.error("Error: missing either bucket name, full filename, targetBucket or targetKey!");
-    return;
+var decompress = function (/* String */command, /* Function */ cb) {
+  const targetBucket = Object.prototype.hasOwnProperty.call(command, 'targetBucket') ? command.targetBucket : command.bucket
+  let targetFolder = Object.prototype.hasOwnProperty.call(command, 'targetFolder') ? command.targetFolder : ''
+  if (targetFolder.length > 0) targetFolder += '/'
+  if (!command.bucket || !command.file) { // bucket and file are required
+    if (cb) cb(new Error('Error: missing either bucket name, full filename, targetBucket or targetKey!'))
+    else console.error('Error: missing either bucket name, full filename, targetBucket or targetKey!')
+    return
   }
 
-  var filenamePartsArray = command.file.split(".");
-  var foldername = filenamePartsArray[0];
+  s3.getObject({
+    Bucket: command.bucket,
+    Key: command.file
+  }, function (err, data) {
+    if (err) {
+      if (cb) cb(new Error('File Error: ' + err.message))
+      else console.error('File Error: ' + err.message)
+    } else {
+      if (command.verbose) console.log('Zip file \'' + command.file + '\' found in S3 bucket!')
 
-  s3.getObject(
-    {
-      Bucket: command.bucket,
-      Key: foldername+"/"
-    }, function(err, data) {
-      if (data) {
-        //TODO: if called via command line, ask here to overwrite the data and prompt for response
-        //console.log("Folder '"+foldername+"' already exists!");
+      var metadata = {}
+      if (command.copyMetadata) {
+        metadata = data.Metadata
+        console.log('zip metadata', metadata)
       }
 
-      s3.getObject(
-        {
-          Bucket: command.bucket,
-          Key: command.file
-        }, function(err, data) {
+      // write the zip file locally in a tmp dir
+      var tmpZipFilename = md5(dateTime({ showMilliseconds: true }))
+      fs.writeFileSync('/tmp/' + tmpZipFilename + '.zip', data.Body)
+
+      // check that file in that location is a zip content type, otherwise throw error and exit
+      if (mime.lookup('/tmp/' + tmpZipFilename + '.zip') !== 'application/zip') {
+        if (cb) cb(new Error('Error: file is not of type zip. Please select a valid file (filename.zip).'))
+        else console.error('Error: file is not of type zip. Please select a valid file (filename.zip).')
+        fs.unlinkSync('/tmp/' + tmpZipFilename + '.zip')
+        return
+      }
+
+      var zip, zipEntries, zipEntryCount
+      // find all files in the zip and the count of them
+      try {
+        zip = new AdmZip('/tmp/' + tmpZipFilename + '.zip')
+        zipEntries = zip.getEntries()
+        zipEntryCount = Object.keys(zipEntries).length
+      } catch (err) {
+        cb(err)
+      }
+
+      // if no files found in the zip
+      if (zipEntryCount === 0) {
+        if (cb) cb(new Error('Error: the zip file was empty!'))
+        else console.error('Error: the zip file was empty!')
+        fs.unlinkSync('/tmp/' + tmpZipFilename + '.zip')
+        return
+      }
+
+      // for each file in the zip, decompress and upload it to S3; once all are uploaded, delete the tmp zip and zip on S3
+      var counter = 0
+      zipEntries.forEach(function (zipEntry) {
+        s3.upload({ Bucket: targetBucket, Key: targetFolder + zipEntry.entryName, Body: zipEntry.getData(), Metadata: metadata }, function (err, data) {
+          counter++
+
           if (err) {
-           	if (cb) cb(new Error("File Error: "+err.message));
-            else console.error("File Error: "+err.message);
-            return;
+            if (cb) cb(new Error('Upload Error: ' + err.message))
+            else console.error('Upload Error: ' + err.message)
+            fs.unlinkSync('/tmp/' + tmpZipFilename + '.zip')
+            return
           }
-          else {
-           	if (command.verbose) console.log("Zip file '"+command.file+"' found in S3 bucket!");
 
-            var metadata = {};
-            if (command.copyMetadata) {
-              metadata = data.Metadata;
-              console.log('Copying metadata');
-            }
+          if (command.verbose) console.log('File decompressed to S3: ' + data.Location)
 
-            //write the zip file locally in a tmp dir
-            var tmpZipFilename = md5(dateTime({showMilliseconds: true}));
-            fs.writeFileSync("/tmp/"+tmpZipFilename+".zip", data.Body);
+          // if all files are unzipped...
+          if (zipEntryCount === counter) {
+            // delete the tmp (local) zip file
+            fs.unlinkSync('/tmp/' + tmpZipFilename + '.zip')
 
-            //check that file in that location is a zip content type, otherwise throw error and exit
-           	if (mime.lookup("/tmp/"+tmpZipFilename+".zip") !== "application/zip") {
-           		if (cb) cb(new Error("Error: file is not of type zip. Please select a valid file (filename.zip)."));
-              else console.error("Error: file is not of type zip. Please select a valid file (filename.zip).");
-              fs.unlinkSync("/tmp/"+tmpZipFilename+".zip");
-              return;
-           	}
+            if (command.verbose) console.log('Local temp zip file deleted.')
 
-           	var zip, zipEntries, zipEntryCount;
-            //find all files in the zip and the count of them
-              try {
-                  zip = new AdmZip("/tmp/" + tmpZipFilename + ".zip");
-                  zipEntries = zip.getEntries();
-                  zipEntryCount = Object.keys(zipEntries).length;
-              } catch (err) {
-           	      cb(err);
-              }
-
-            //if no files found in the zip
-            if (zipEntryCount === 0){
-              if (cb) cb(new Error("Error: the zip file was empty!"));
-              else console.error("Error: the zip file was empty!");
-              fs.unlinkSync("/tmp/"+tmpZipFilename+".zip");
-              return;
-            }
-
-            //for each file in the zip, decompress and upload it to S3; once all are uploaded, delete the tmp zip and zip on S3
-            var counter = 0;
-          	zipEntries.forEach(function(zipEntry) {
-              s3.upload({ Bucket: targetBucket, Key: targetFolder+zipEntry.entryName, Body: zipEntry.getData(), Metadata: metadata }, function(err, data) {
-                counter++;
-
+            // delete the zip file up on S3
+            if (command.deleteOnSuccess) {
+              s3.deleteObject({ Bucket: command.bucket, Key: command.file }, function (err) {
                 if (err) {
-                  if (cb) cb(new Error("Upload Error: "+err.message));
-                  else console.error("Upload Error: "+err.message);
-                  fs.unlinkSync("/tmp/"+tmpZipFilename+".zip");
-                  return;
+                  if (cb) cb(new Error('Delete Error: ' + err.message))
+                  else console.error('Delete Error: ' + err.message)
+                  return
                 }
 
-                if (command.verbose) console.log("File decompressed to S3: "+data.Location);
+                if (command.verbose) console.log('S3 file \'' + command.file + '\' deleted.')
 
-                //if all files are unzipped...
-                if (zipEntryCount === counter){
-                  //delete the tmp (local) zip file
-                  fs.unlinkSync("/tmp/"+tmpZipFilename+".zip");
-
-                  if (command.verbose) console.log("Local temp zip file deleted.");
-
-                  //delete the zip file up on S3
-                  if (command.deleteOnSuccess) {
-                    s3.deleteObject({Bucket: command.bucket, Key: command.file}, function(err, data) {
-                      if (err) {
-                        if (cb) cb(new Error("Delete Error: "+err.message));
-                        else console.error("Delete Error: "+err.message);
-                        return;
-                      }
-
-                      if (command.verbose) console.log("S3 file '"+command.file+"' deleted.");
-
-                      //WE GOT TO THE END
-                      cb(null, "Success!");
-                    });
-                  }else {
-                    //WE GOT TO THE END
-                    cb(null, "Success!");
-                  }
-                }
-              });
-          	});
+                // WE GOT TO THE END
+                cb(null, 'Success!')
+              })
+            } else {
+              // WE GOT TO THE END
+              cb(null, 'Success!')
+            }
           }
-        }
-      );
+        })
+      })
     }
-  );
+  }
+  )
 }
 
 module.exports = {

--- a/util.js
+++ b/util.js
@@ -66,6 +66,12 @@ var decompress = function(/*String*/command, /*Function*/ cb) {
           else {
            	if (command.verbose) console.log("Zip file '"+command.file+"' found in S3 bucket!");
 
+            var metadata = {};
+            if (command.copyMetadata) {
+              metadata = data.Metadata;
+              console.log('Copying metadata');
+            }
+
             //write the zip file locally in a tmp dir
             var tmpZipFilename = md5(dateTime({showMilliseconds: true}));
             fs.writeFileSync("/tmp/"+tmpZipFilename+".zip", data.Body);
@@ -99,7 +105,7 @@ var decompress = function(/*String*/command, /*Function*/ cb) {
             //for each file in the zip, decompress and upload it to S3; once all are uploaded, delete the tmp zip and zip on S3
             var counter = 0;
           	zipEntries.forEach(function(zipEntry) {
-              s3.upload({ Bucket: targetBucket, Key: targetFolder+zipEntry.entryName, Body: zipEntry.getData() }, function(err, data) {
+              s3.upload({ Bucket: targetBucket, Key: targetFolder+zipEntry.entryName, Body: zipEntry.getData(), Metadata: metadata }, function(err, data) {
                 counter++;
 
                 if (err) {


### PR DESCRIPTION
This feature adds a **copyMetadata** flag to allow copying S3 object Metadata from parent zip file to child files that have been unzipped and stored in S3.

```
var s = new s3Unziplus({
    bucket: "test-bucket-in-s3",
    file: "Companies.zip",
    targetBucket: "test-output-bucket",
    targetKey: "test-folder",
    deleteOnSuccess: true,
    copyMetadata: true,
    verbose: false
  }, function(err, success){
    if (err) console.error(err);
    else console.log(success);
  });
```